### PR TITLE
Fix clear_code service schema and logic and set_code service logic

### DIFF
--- a/custom_components/lock-manager/__init__.py
+++ b/custom_components/lock-manager/__init__.py
@@ -117,12 +117,13 @@ async def async_setup_entry(hass, config_entry):
 
         _LOGGER.debug("Attempting to call set_usercode...")
 
+        servicedata = {
+            ATTR_CODE_SLOT: code_slot,
+            ATTR_USER_CODE: usercode,
+        }
+
         if using_ozw:
-            servicedata = {
-                ATTR_ENTITY_ID: entity_id,
-                ATTR_CODE_SLOT: code_slot,
-                ATTR_USER_CODE: usercode,
-            }
+            servicedata[ATTR_ENTITY_ID] =  entity_id
 
             try:
                 await hass.services.async_call(OZW_DOMAIN, SET_USERCODE, servicedata)
@@ -143,11 +144,7 @@ async def async_setup_entry(hass, config_entry):
                 _LOGGER.error("Problem pulling node_id from entity.")
                 return
 
-            servicedata = {
-                ATTR_NODE_ID: node_id,
-                ATTR_CODE_SLOT: code_slot,
-                ATTR_USER_CODE: usercode,
-            }
+            servicedata[ATTR_NODE_ID] = node_id
 
             try:
                 await hass.services.async_call(ZWAVE_DOMAIN, SET_USERCODE, servicedata)
@@ -169,11 +166,10 @@ async def async_setup_entry(hass, config_entry):
 
         _LOGGER.debug("Attempting to call clear_usercode...")
 
+        servicedata = {ATTR_CODE_SLOT: code_slot}
+
         if using_ozw:
-            servicedata = {
-                ATTR_ENTITY_ID: entity_id,
-                ATTR_CODE_SLOT: code_slot,
-            }
+            servicedata[ATTR_ENTITY_ID] = entity_id
 
             try:
                 await hass.services.async_call(OZW_DOMAIN, CLEAR_USERCODE, servicedata)
@@ -193,10 +189,7 @@ async def async_setup_entry(hass, config_entry):
                 _LOGGER.error("Problem pulling node_id from entity.")
                 return
 
-            servicedata = {
-                ATTR_NODE_ID: node_id,
-                ATTR_CODE_SLOT: code_slot,
-            }
+            servicedata[ATTR_NODE_ID] = node_id
 
             try:
                 await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
I don't think the `clear_code` service schema made sense because the function expects to get an `entity_id` not a `node_id`. In addition, when not using `ozw`, the function was calling the `zwave` integrations `clear_usercodes` and `set_usercode` service with the `entity_id` instead of the `node_id`. This PR resolves both issues. I did a little bit of cleanup while I was there which is why this change looks bigger than it functionally is.

NOTE: I don't *think* this is a breaking change because I don't see how this service could have possibly worked in the past. But feel free to correct me if I am wrong and I can add the necessary comment to the PR


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
