### PR TITLE
Add ozw and zwave as after_dependencies

### DIFF
--- a/custom_components/lock-manager/manifest.json
+++ b/custom_components/lock-manager/manifest.json
@@ -3,6 +3,7 @@
   "name": "lock-manager",
   "documentation": "https://github.com/FutureTense/lock-manager",
   "dependencies": [],
+  "after_dependencies": ["ozw", "zwave"],
   "codeowners": ["@FutureTense", "@firstof9"],
   "config_flow": true,
   "issue_tracker": "https://github.com/FutureTense/lock-manager/issues",


### PR DESCRIPTION
## Proposed change
This should resolve the `hassfest` CI errors and the nice benefit is that `lock-manager` is guaranteed to load after either integration ([`dependencies`](https://developers.home-assistant.io/docs/creating_integration_manifest#dependencies) are for integrations that *must* be enabled and available for the integration to load, [`after_dependencies`](https://developers.home-assistant.io/docs/creating_integration_manifest#after-dependencies) will wait for integrations that are listed to be available if they are enabled before loading this integration).

I haven't looked too deeply into the automations that you have set up to enable and disable alerting but this should make it easier to remove that extra logic.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
